### PR TITLE
updating phenotype generator dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ could provide a score for each dimension.
 ### How do I participate?
 
 What are you waiting for? <a href="https://rseng.github.io/rse-phenotype">Generate your phenotype</a> and tell us about it!
+
+## Thank You!
+
+Thank you to [chrispahm/chartjs-plugin-dragdata](https://github.com/chrispahm/chartjs-plugin-dragdata)
+for providing the library to make dragging of the points possible.

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
 <script src="https://unpkg.com/vue-chartjs/dist/vue-chartjs.min.js"></script>
 <!--https://github.com/chrispahm/chartjs-plugin-dragData-->
-<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-dragdata@0.3.0/dist/chartjs-plugin-dragData.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-dragdata@1.1.3/dist/chartjs-plugin-dragdata.min.js"></script>
 <script src="rse-phenotype.js"></script>
 
 </body>

--- a/rse-phenotype.js
+++ b/rse-phenotype.js
@@ -203,6 +203,9 @@ new Vue ({
           },
           options: {
             dragData: true,
+            dragOptions: {
+                showTooltip: true,
+            },
             onDragEnd: function (e, datasetIndex, index, value) { 
               // update saved values
               if (localStorage.values) {


### PR DESCRIPTION
version 1.1.3. now supports a dragOption that allows to show the value of the points while the user is dragging, which is hugely useful! This change will update the version and add this setting. We also give a shoutout to https://github.com/chrispahm/chartjs-plugin-dragdata for the plugin! Thank you @chrispahm! 

Signed-off-by: vsoch <vsochat@stanford.edu>