### PR TITLE
Fixing bug that lenght isnt correct for number of groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en" >
-
 <head>
   <meta charset="UTF-8">
   <title>Research Software Engineer Generator</title>
@@ -17,7 +16,6 @@
   <link rel="stylesheet" href="css/custom.css">
   <link rel="icon" type="image/png" href="favicon.ico">
 </head>
-
 <body>
 
 

--- a/rse-phenotype.js
+++ b/rse-phenotype.js
@@ -99,7 +99,6 @@ new Vue ({
       // Generate datasets if not loaded from cache
       var datasets = Array();
       var groups = this.getGroups();
-      console.log(this.values)
 
       // If values aren't null but are wrong length, reset
       if ((this.values != null) || (this.values.length != groups.length)) {

--- a/rse-phenotype.js
+++ b/rse-phenotype.js
@@ -207,6 +207,14 @@ new Vue ({
             dragOptions: {
                 showTooltip: true,
             },
+            // Don't auto resize scale
+            scale: {
+                ticks: {
+                  max: 100,
+                  min: 0
+                },
+                stepSize: 1
+            },
             onDragEnd: function (e, datasetIndex, index, value) { 
               // update saved values
               if (localStorage.values) {

--- a/rse-phenotype.js
+++ b/rse-phenotype.js
@@ -99,9 +99,10 @@ new Vue ({
       // Generate datasets if not loaded from cache
       var datasets = Array();
       var groups = this.getGroups();
+      console.log(this.values)
 
       // If values aren't null but are wrong length, reset
-      if ((this.values != null) && (this.values.length != groups.length)) {
+      if ((this.values != null) || (this.values.length != groups.length)) {
         console.log("Mismatch between values and groups, resetting values!");
         this.values = null;
       }


### PR DESCRIPTION
We should re-generate the data points given that the values are null OR the dimension is a mis match. The current code expects an and (&&) which will never be true and result in #9 

Signed-off-by: vsoch <vsochat@stanford.edu>